### PR TITLE
Add secure banking chatbot widget and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# trytohelp
+# National Bank Chatbot
+
+A secure, production-ready banking assistant featuring real-time scraping, intent routing, and an embeddable green & white chat widget.
+
+## File tree
+
+```
+.
+├── package.json
+├── jest.config.js
+├── public/
+│   └── widget.js
+├── server/
+│   ├── analytics.js
+│   ├── config.js
+│   ├── fetcher.js
+│   ├── intents.js
+│   ├── locale.js
+│   ├── scraping.js
+│   └── index.js
+├── tests/
+│   ├── fetcher.test.js
+│   ├── intents.test.js
+│   └── scraping.test.js
+└── README.md
+```
+
+## Prerequisites
+
+- Node.js 18+
+- npm or pnpm (examples use npm)
+
+## Installation & local development
+
+```bash
+npm install
+npm run dev
+```
+
+The server listens on `http://localhost:3000` by default and serves the widget from `/public/widget.js`.
+
+## Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `ALLOWED_DOMAINS` | Comma separated list of hostnames the scraper can visit. |
+| `CAREERS_URL` | Absolute URL to the careers page. |
+| `LOANS_URL` | Absolute URL to the loans/products page. |
+| `FAQ_URL` | Official FAQ URL (fallback). |
+| `CONTACT_URL` | Official contact page (handoff + phone/email scraping). |
+| `BRANCHES_URL` | Branch/ATM finder URL. |
+| `SITEMAP_URL` | Sitemap for structured fallback. |
+| `CACHE_TTL_SECONDS` | Cache TTL (default 900 seconds). |
+| `HANDOFF_URL` | Optional human handoff URL. |
+| `DEFAULT_LOCALE` | `en` or `ur` (default `en`). |
+
+## API overview
+
+- `GET /api/health` – health & analytics snapshot.
+- `GET /api/csrf` – retrieves a CSRF token (sets secure cookie).
+- `POST /api/ask` – accepts `{ q: string, locale?: 'en' | 'ur' }` and returns the structured answer payload (`intent`, `message`, `cards`, `sources`, `as_of`, `chips`).
+
+## Testing
+
+```bash
+npm test
+```
+
+Unit coverage includes selector-based scraping, intent routing, and allowlist enforcement.
+
+## Embedding the widget
+
+Add the mount div and script tag anywhere on your public site:
+
+```html
+<div id="bank-chatbot"></div>
+<script src="/public/widget.js" data-api-base="/api" data-locale="en" defer></script>
+```
+
+If you need a different API base or default language, adjust the `data-` attributes accordingly.
+
+## Deployment notes
+
+- Reverse proxy `/api` and `/public` through HTTPS.
+- Ensure environment variables are set with the bank’s canonical domains.
+- Set `NODE_ENV=production` to enforce secure cookies and stricter headers.
+- Logs should capture only intent, success flag, and latency; avoid storing raw questions in production environments.
+
+## Minimal technical spec (for automation/Codex)
+
+- **Frontend**: Vanilla JS widget (`public/widget.js`) with accessible launcher, keyboard focus trap, locale & theme toggles, quick reply chips, card UI, and responsive green/white styling. Fetches CSRF token then posts to `/api/ask` with JSON `{ q, locale }`. Displays cards, sources, timestamps, disclaimer, and supports light/dark themes.
+- **Backend**: Node.js (Express) server (`server/index.js`) using Helmet, CSRF cookies, and rate limiting. Endpoints `/api/csrf`, `/api/health`, `/api/ask`. Intent router (`server/intents.js`) detects jobs/loans/branches/rates/contact/general/handoff intents. Scrapers (`server/scraping.js`) parse careers & loan pages via configurable selectors. Fetcher (`server/fetcher.js`) enforces domain allowlist, robots.txt, caching, and exponential backoff. Responses follow `{ intent, as_of, message, sources[], cards[], chips[], disclaimer, handoff }`. Tests in `tests/` validate scraping, intents, and allowlist behavior.
+- **Security**: No PII capture, strict domain allowlist, sanitized strings, CSRF tokens, rate limiting, caching TTL from env, robots.txt enforcement, and analytics limited to aggregated stats.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+export default {
+  testEnvironment: 'node',
+  collectCoverage: false,
+  roots: ['<rootDir>/tests'],
+  transform: {}
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "bank-chatbot",
+  "version": "1.0.0",
+  "description": "Secure banking chatbot with scraping and intent routing",
+  "type": "module",
+  "main": "server/index.js",
+  "scripts": {
+    "dev": "node server/index.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+  },
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "csurf": "^1.11.0",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.0.0",
+    "helmet": "^7.0.0",
+    "jsdom": "^23.0.1",
+    "lru-cache": "^10.2.0",
+    "robots-parser": "^3.0.1"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "jest": "^29.7.0"
+  }
+}

--- a/public/widget.js
+++ b/public/widget.js
@@ -1,0 +1,813 @@
+(function () {
+  const scriptEl = document.currentScript;
+  const datasetConfig = scriptEl ? {
+    apiBase: scriptEl.getAttribute('data-api-base'),
+    locale: scriptEl.getAttribute('data-locale')
+  } : {};
+  const globalConfig = window.BankChatbot || {};
+  const config = {
+    apiBase: datasetConfig.apiBase || globalConfig.apiBase || '/api',
+    locale: datasetConfig.locale || globalConfig.locale || 'en'
+  };
+
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const state = {
+    open: false,
+    locale: config.locale,
+    csrf: null,
+    busy: false,
+    theme: prefersDark ? 'dark' : 'light'
+  };
+
+  const localeLabels = {
+    en: 'English',
+    ur: 'اردو'
+  };
+
+  const mountId = 'bank-chatbot';
+
+  function h(tag, attrs, ...children) {
+    const el = document.createElement(tag);
+    if (attrs) {
+      Object.entries(attrs).forEach(([key, value]) => {
+        if (value == null) return;
+        if (key === 'class') {
+          el.className = value;
+        } else if (key === 'style') {
+          Object.assign(el.style, value);
+        } else if (key.startsWith('on') && typeof value === 'function') {
+          el.addEventListener(key.slice(2), value);
+        } else if (key === 'dataset') {
+          Object.entries(value).forEach(([dataKey, dataValue]) => {
+            el.dataset[dataKey] = dataValue;
+          });
+        } else {
+          el.setAttribute(key, value);
+        }
+      });
+    }
+    children.flat().forEach((child) => {
+      if (child == null) return;
+      if (typeof child === 'string' || typeof child === 'number') {
+        el.appendChild(document.createTextNode(child));
+      } else {
+        el.appendChild(child);
+      }
+    });
+    return el;
+  }
+
+  function sanitizeUrl(url) {
+    try {
+      const parsed = new URL(url, window.location.origin);
+      return parsed.href;
+    } catch (error) {
+      return '#';
+    }
+  }
+
+  let logEl;
+  let panelEl;
+  let launcherEl;
+  let inputEl;
+  let sendEl;
+  let chipsEl;
+  let localeToggleEl;
+  let themeToggleEl;
+  let wrapperEl;
+
+  function focusableElements(container) {
+    return Array.from(
+      container.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => !el.hasAttribute('disabled'));
+  }
+
+  function applyTheme() {
+    if (wrapperEl) {
+      wrapperEl.dataset.theme = state.theme;
+    }
+  }
+
+  function trapFocus(event) {
+    if (event.key !== 'Tab') return;
+    const focusables = focusableElements(panelEl);
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        last.focus();
+        event.preventDefault();
+      }
+    } else if (document.activeElement === last) {
+      first.focus();
+      event.preventDefault();
+    }
+  }
+
+  function openPanel() {
+    state.open = true;
+    panelEl.setAttribute('aria-hidden', 'false');
+    panelEl.classList.add('bc-open');
+    launcherEl.setAttribute('aria-expanded', 'true');
+    panelEl.addEventListener('keydown', trapFocus);
+    panelEl.focus();
+  }
+
+  function closePanel() {
+    state.open = false;
+    panelEl.setAttribute('aria-hidden', 'true');
+    panelEl.classList.remove('bc-open');
+    launcherEl.setAttribute('aria-expanded', 'false');
+    panelEl.removeEventListener('keydown', trapFocus);
+  }
+
+  async function ensureCsrf() {
+    if (state.csrf) return state.csrf;
+    const res = await fetch(`${config.apiBase}/csrf`, {
+      credentials: 'same-origin'
+    });
+    if (!res.ok) throw new Error('Unable to obtain CSRF token');
+    const data = await res.json();
+    state.csrf = data.token;
+    return state.csrf;
+  }
+
+  function appendBubble(contentEl, role) {
+    const bubble = h('div', { class: `bc-bubble bc-${role}` }, contentEl);
+    logEl.appendChild(bubble);
+    bubble.setAttribute('aria-live', role === 'bot' ? 'polite' : 'off');
+    requestAnimationFrame(() => {
+      bubble.classList.add('bc-bubble-in');
+      logEl.scrollTo({ top: logEl.scrollHeight, behavior: 'smooth' });
+    });
+  }
+
+  function renderMessageBubble(message, response) {
+    const container = h('div', { class: 'bc-msg' });
+    container.appendChild(h('p', { class: 'bc-msg-text' }, message));
+    if (response && Array.isArray(response.cards) && response.cards.length) {
+      const cardsWrap = h('div', { class: 'bc-cards' });
+      response.cards.forEach((card) => {
+        const cardEl = h('div', { class: 'bc-card' });
+        cardEl.appendChild(h('div', { class: 'bc-card-title' }, card.title || ''));
+        if (card.subtitle) {
+          cardEl.appendChild(h('div', { class: 'bc-card-sub' }, card.subtitle));
+        }
+        if (Array.isArray(card.badges) && card.badges.length) {
+          const badges = h('div', { class: 'bc-card-badges' });
+          card.badges.forEach((badge) => {
+            badges.appendChild(h('span', { class: 'bc-badge' }, badge));
+          });
+          cardEl.appendChild(badges);
+        }
+        if (Array.isArray(card.actions) && card.actions.length) {
+          const actions = h('div', { class: 'bc-card-actions' });
+          card.actions.forEach((action) => {
+            actions.appendChild(
+              h(
+                'a',
+                {
+                  class: 'bc-btn',
+                  href: sanitizeUrl(action.href),
+                  target: '_blank',
+                  rel: 'noopener',
+                  tabindex: '0'
+                },
+                action.label || 'Open'
+              )
+            );
+          });
+          cardEl.appendChild(actions);
+        }
+        cardsWrap.appendChild(cardEl);
+      });
+      container.appendChild(cardsWrap);
+    }
+    if (response && Array.isArray(response.sources) && response.sources.length) {
+      const src = h('div', { class: 'bc-src', role: 'note' }, 'Sources: ');
+      response.sources.forEach((link, index) => {
+        src.appendChild(
+          h(
+            'a',
+            { href: sanitizeUrl(link), target: '_blank', rel: 'noopener', class: 'bc-src-link' },
+            link
+          )
+        );
+        if (index < response.sources.length - 1) {
+          src.appendChild(document.createTextNode(' • '));
+        }
+      });
+      container.appendChild(src);
+    }
+    if (response && response.as_of) {
+      const time = new Date(response.as_of);
+      container.appendChild(h('div', { class: 'bc-ts' }, `Information as of ${time.toLocaleString()}`));
+    }
+    if (response && response.disclaimer) {
+      container.appendChild(h('div', { class: 'bc-disclaimer' }, response.disclaimer));
+    }
+    return container;
+  }
+
+  function renderChips(chips) {
+    chipsEl.innerHTML = '';
+    if (!Array.isArray(chips) || !chips.length) return;
+    chips.forEach((chip) => {
+      const button = h(
+        'button',
+        {
+          class: 'bc-chip',
+          type: 'button',
+          onclick: () => {
+            inputEl.value = chip.value;
+            inputEl.focus();
+          }
+        },
+        chip.label
+      );
+      chipsEl.appendChild(button);
+    });
+  }
+
+  async function ask(question) {
+    if (!question || state.busy) return;
+    state.busy = true;
+    sendEl.setAttribute('disabled', 'true');
+    inputEl.setAttribute('aria-busy', 'true');
+    appendBubble(h('div', { class: 'bc-msg-user' }, question), 'user');
+    inputEl.value = '';
+    try {
+      const token = await ensureCsrf();
+      const res = await fetch(`${config.apiBase}/ask`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': token
+        },
+        body: JSON.stringify({ q: question, locale: state.locale })
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      state.locale = data.locale || state.locale;
+      renderChips(data.chips);
+      appendBubble(renderMessageBubble(data.message || '', data), 'bot');
+    } catch (error) {
+      appendBubble(
+        renderMessageBubble(
+          'Sorry, I ran into a problem. Please use the official website links while we investigate.',
+          null
+        ),
+        'bot'
+      );
+    } finally {
+      state.busy = false;
+      sendEl.removeAttribute('disabled');
+      inputEl.removeAttribute('aria-busy');
+      inputEl.focus();
+    }
+  }
+
+  function handleSend() {
+    const text = inputEl.value.trim();
+    if (!text) return;
+    ask(text);
+  }
+
+  function createWidget() {
+    wrapperEl = h('div', { class: 'bc-wrapper', role: 'presentation' });
+    applyTheme();
+
+    launcherEl = h(
+      'button',
+      {
+        class: 'bc-launcher',
+        'aria-expanded': 'false',
+        'aria-controls': 'bc-panel',
+        'aria-label': 'Open bank assistant',
+        onclick: () => {
+          if (state.open) closePanel();
+          else openPanel();
+        }
+      },
+      h('span', { class: 'bc-launcher-label' }, 'Need help?'),
+      h('span', { class: 'bc-launcher-icon', 'aria-hidden': 'true' })
+    );
+
+    const header = h(
+      'header',
+      { class: 'bc-header' },
+      h('div', { class: 'bc-title' }, 'National Bank Assistant'),
+      h(
+        'button',
+        {
+          class: 'bc-close',
+          type: 'button',
+          'aria-label': 'Close chat',
+          onclick: closePanel
+        },
+        '×'
+      )
+    );
+
+    const langOptions = Object.keys(localeLabels).map((key) =>
+      h('option', { value: key, selected: key === state.locale }, localeLabels[key])
+    );
+    localeToggleEl = h(
+      'select',
+      {
+        class: 'bc-locale',
+        onchange: (event) => {
+          state.locale = event.target.value;
+          ensureCsrf().catch(() => {});
+        },
+        'aria-label': 'Select language'
+      },
+      langOptions
+    );
+
+    themeToggleEl = h(
+      'button',
+      {
+        class: 'bc-theme',
+        type: 'button',
+        'aria-label': 'Toggle theme',
+        onclick: () => {
+          state.theme = state.theme === 'dark' ? 'light' : 'dark';
+          applyTheme();
+        }
+      },
+      '◐'
+    );
+
+    const headerMeta = h(
+      'div',
+      { class: 'bc-header-meta' },
+      h('span', { class: 'bc-powered' }, 'Powered by National Bank Assistant'),
+      h('div', { class: 'bc-header-controls' }, themeToggleEl, localeToggleEl)
+    );
+    header.appendChild(headerMeta);
+
+    logEl = h('div', { class: 'bc-log', role: 'log', tabindex: '0' });
+
+    chipsEl = h('div', { class: 'bc-chips', role: 'list' });
+
+    inputEl = h('input', {
+      class: 'bc-input',
+      type: 'text',
+      placeholder: 'Ask about jobs, loans, branches…',
+      'aria-label': 'Type your question'
+    });
+    inputEl.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleSend();
+      }
+      if (event.key === 'Escape') {
+        closePanel();
+      }
+    });
+
+    sendEl = h(
+      'button',
+      { class: 'bc-send', type: 'button', 'aria-label': 'Send message', onclick: handleSend },
+      'Send'
+    );
+
+    const disclaimerBar = h('div', { class: 'bc-privacy' }, 'No account information is processed in this chat.');
+
+    const inputBar = h('div', { class: 'bc-inputbar' }, inputEl, sendEl);
+
+    panelEl = h(
+      'section',
+      {
+        class: 'bc-panel',
+        id: 'bc-panel',
+        role: 'dialog',
+        'aria-modal': 'true',
+        tabindex: '-1',
+        'aria-hidden': 'true'
+      },
+      header,
+      disclaimerBar,
+      logEl,
+      chipsEl,
+      inputBar
+    );
+
+    panelEl.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closePanel();
+        launcherEl.focus();
+      }
+    });
+
+    wrapperEl.appendChild(panelEl);
+    wrapperEl.appendChild(launcherEl);
+    return wrapperEl;
+  }
+
+  function injectStyles() {
+    if (document.getElementById('bc-style')) return;
+    const css = `
+    :root {
+      --brand-green: #0b7a4b;
+      --brand-green-600: #0a5f3b;
+      --brand-green-200: #c8f5e1;
+      --bg: #ffffff;
+      --text: #0f172a;
+      --muted: #4b5563;
+      --surface: #f7faf9;
+      --border: rgba(15, 23, 42, 0.08);
+      --radius: 16px;
+    }
+    [data-theme='dark'] {
+      --bg: #0b1720;
+      --text: #f8fafc;
+      --surface: #13212b;
+      --border: rgba(148, 163, 184, 0.16);
+      --muted: #94a3b8;
+    }
+    .bc-wrapper {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      z-index: 2147483000;
+      font-family: 'Segoe UI', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+      color: var(--text);
+    }
+    .bc-launcher {
+      background: var(--brand-green);
+      color: #fff;
+      border: none;
+      border-radius: 999px;
+      padding: 12px 18px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+      box-shadow: 0 12px 40px rgba(11, 122, 75, 0.35);
+      transition: transform 160ms ease, box-shadow 160ms ease;
+    }
+    .bc-launcher:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 18px 44px rgba(11, 122, 75, 0.42);
+    }
+    .bc-launcher:focus-visible {
+      outline: 3px solid var(--brand-green-200);
+      outline-offset: 2px;
+    }
+    .bc-launcher-icon {
+      width: 12px;
+      height: 12px;
+      border-right: 2px solid #fff;
+      border-bottom: 2px solid #fff;
+      transform: rotate(-45deg);
+      margin-top: -2px;
+    }
+    .bc-panel {
+      width: min(360px, 90vw);
+      max-height: min(80vh, 640px);
+      background: var(--bg);
+      border-radius: var(--radius);
+      box-shadow: 0 24px 64px rgba(15, 23, 42, 0.28);
+      border: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      opacity: 0;
+      transform: scale(0.95);
+      pointer-events: none;
+      transition: opacity 180ms ease, transform 180ms ease;
+    }
+    .bc-panel.bc-open {
+      opacity: 1;
+      transform: scale(1);
+      pointer-events: auto;
+    }
+    .bc-header {
+      padding: 16px;
+      background: linear-gradient(135deg, rgba(11, 122, 75, 0.92), rgba(11, 122, 75, 0.75));
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      position: relative;
+    }
+    .bc-title {
+      font-weight: 600;
+      font-size: 1.1rem;
+      letter-spacing: 0.01em;
+    }
+    .bc-close {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      background: rgba(255, 255, 255, 0.18);
+      color: #fff;
+      border: none;
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      cursor: pointer;
+      font-size: 20px;
+      line-height: 1;
+      transition: background 150ms ease;
+    }
+    .bc-close:hover {
+      background: rgba(255, 255, 255, 0.32);
+    }
+    .bc-close:focus-visible {
+      outline: 3px solid var(--brand-green-200);
+    }
+    .bc-header-meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 12px;
+      gap: 12px;
+    }
+    .bc-header-controls {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .bc-powered {
+      opacity: 0.9;
+    }
+    .bc-locale {
+      background: rgba(255, 255, 255, 0.22);
+      border-radius: 999px;
+      border: none;
+      padding: 6px 10px;
+      color: #fff;
+      font-size: 12px;
+    }
+    .bc-theme {
+      background: rgba(255, 255, 255, 0.22);
+      border: none;
+      border-radius: 999px;
+      width: 32px;
+      height: 32px;
+      color: #fff;
+      cursor: pointer;
+      font-size: 16px;
+      display: grid;
+      place-items: center;
+    }
+    .bc-theme:focus-visible {
+      outline: 2px solid var(--brand-green-200);
+      outline-offset: 2px;
+    }
+    .bc-log {
+      flex: 1;
+      padding: 18px;
+      overflow-y: auto;
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      scrollbar-width: thin;
+    }
+    .bc-log:focus-visible {
+      outline: 3px solid var(--brand-green-200);
+      outline-offset: -4px;
+    }
+    .bc-privacy {
+      padding: 10px 16px;
+      font-size: 12px;
+      background: rgba(255, 255, 255, 0.9);
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+    }
+    .bc-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 10px 18px 0;
+    }
+    .bc-chip {
+      border: 1px solid rgba(11, 122, 75, 0.24);
+      border-radius: 999px;
+      padding: 6px 12px;
+      background: #fff;
+      color: var(--brand-green);
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .bc-chip:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 20px rgba(11, 122, 75, 0.2);
+    }
+    .bc-chip:focus-visible {
+      outline: 2px solid var(--brand-green);
+      outline-offset: 2px;
+    }
+    .bc-inputbar {
+      display: flex;
+      gap: 10px;
+      padding: 16px;
+      background: var(--bg);
+      border-top: 1px solid var(--border);
+    }
+    .bc-input {
+      flex: 1;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      padding: 12px 16px;
+      font-size: 15px;
+      color: var(--text);
+      background: #fff;
+    }
+    .bc-input:focus-visible {
+      outline: 2px solid var(--brand-green);
+      outline-offset: 2px;
+    }
+    .bc-send {
+      background: var(--brand-green);
+      color: #fff;
+      border: none;
+      padding: 12px 18px;
+      border-radius: 999px;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .bc-send:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+    .bc-send:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(11, 122, 75, 0.3);
+    }
+    .bc-send:focus-visible {
+      outline: 2px solid var(--brand-green-200);
+      outline-offset: 2px;
+    }
+    .bc-bubble {
+      max-width: 100%;
+      background: #fff;
+      border-radius: 16px;
+      padding: 14px 16px;
+      box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+      align-self: flex-start;
+      opacity: 0;
+      transform: translateY(12px);
+      animation: bc-bubble-in 180ms ease forwards;
+    }
+    .bc-bubble.bc-user {
+      background: var(--brand-green);
+      color: #fff;
+      margin-left: auto;
+      border-bottom-right-radius: 4px;
+    }
+    .bc-bubble.bc-bot {
+      margin-right: auto;
+      border-bottom-left-radius: 4px;
+    }
+    .bc-msg-text {
+      margin: 0 0 8px 0;
+      line-height: 1.45;
+      font-size: 15px;
+    }
+    .bc-card {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px;
+      margin-top: 10px;
+      background: #fff;
+      box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+    }
+    .bc-cards {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .bc-card-title {
+      font-weight: 600;
+      font-size: 14px;
+      color: var(--text);
+    }
+    .bc-card-sub {
+      font-size: 13px;
+      margin-top: 4px;
+      color: var(--muted);
+    }
+    .bc-badge {
+      display: inline-block;
+      background: var(--brand-green-200);
+      color: var(--brand-green-600);
+      padding: 4px 8px;
+      border-radius: 999px;
+      font-size: 11px;
+      margin-right: 6px;
+      margin-top: 6px;
+    }
+    .bc-card-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+    .bc-btn {
+      border-radius: 999px;
+      padding: 8px 14px;
+      background: var(--brand-green);
+      color: #fff;
+      text-decoration: none;
+      font-size: 13px;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+    .bc-btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px rgba(11, 122, 75, 0.28);
+    }
+    .bc-btn:focus-visible {
+      outline: 2px solid var(--brand-green-200);
+      outline-offset: 2px;
+    }
+    .bc-src {
+      font-size: 12px;
+      margin-top: 12px;
+      color: var(--muted);
+    }
+    .bc-src-link {
+      color: var(--brand-green);
+      text-decoration: underline;
+    }
+    .bc-ts {
+      font-size: 11px;
+      color: var(--muted);
+      margin-top: 8px;
+    }
+    .bc-disclaimer {
+      font-size: 11px;
+      color: var(--muted);
+      margin-top: 6px;
+    }
+    @keyframes bc-bubble-in {
+      from {
+        opacity: 0;
+        transform: translateY(12px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+    @media (max-width: 600px) {
+      .bc-wrapper {
+        bottom: 0;
+        right: 0;
+        left: 0;
+        width: 100%;
+        padding: 0 16px 16px;
+      }
+      .bc-panel {
+        width: 100%;
+        max-height: calc(100vh - 32px);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+    `;
+    const style = document.createElement('style');
+    style.id = 'bc-style';
+    style.appendChild(document.createTextNode(css));
+    document.head.appendChild(style);
+  }
+
+  function ensureMount() {
+    let mount = document.getElementById(mountId);
+    if (!mount) {
+      mount = h('div', { id: mountId });
+      document.body.appendChild(mount);
+    }
+    return mount;
+  }
+
+  function init() {
+    injectStyles();
+    const mount = ensureMount();
+    const widget = createWidget();
+    mount.appendChild(widget);
+    ensureCsrf().catch(() => {});
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/server/analytics.js
+++ b/server/analytics.js
@@ -1,0 +1,39 @@
+const totals = {
+  total: 0,
+  successes: 0,
+  failures: 0,
+  intents: new Map(),
+  latencyMs: []
+};
+
+export function recordMetric({ intent, success, latencyMs }) {
+  totals.total += 1;
+  if (success) totals.successes += 1;
+  else totals.failures += 1;
+  if (intent) {
+    const current = totals.intents.get(intent) || 0;
+    totals.intents.set(intent, current + 1);
+  }
+  if (typeof latencyMs === 'number') {
+    totals.latencyMs.push(latencyMs);
+    if (totals.latencyMs.length > 500) {
+      totals.latencyMs.shift();
+    }
+  }
+}
+
+export function snapshotMetrics() {
+  const averageLatency = totals.latencyMs.length
+    ? Math.round(totals.latencyMs.reduce((a, b) => a + b, 0) / totals.latencyMs.length)
+    : 0;
+  const intents = {};
+  totals.intents.forEach((count, intent) => {
+    intents[intent] = count;
+  });
+  return {
+    totalInteractions: totals.total,
+    successRate: totals.total ? Number((totals.successes / totals.total).toFixed(2)) : 0,
+    averageLatencyMs: averageLatency,
+    intents
+  };
+}

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,43 @@
+export const config = {
+  port: Number(process.env.PORT || 3000),
+  allowedDomains: (process.env.ALLOWED_DOMAINS || '')
+    .split(',')
+    .map((d) => d.trim())
+    .filter(Boolean),
+  cacheTtlMs: Number(process.env.CACHE_TTL_SECONDS || 900) * 1000,
+  careersUrl: process.env.CAREERS_URL || '',
+  loansUrl: process.env.LOANS_URL || '',
+  faqUrl: process.env.FAQ_URL || '',
+  contactUrl: process.env.CONTACT_URL || '',
+  branchesUrl: process.env.BRANCHES_URL || '',
+  sitemapUrl: process.env.SITEMAP_URL || '',
+  localeDefault: process.env.DEFAULT_LOCALE || 'en'
+};
+
+export const selectors = {
+  careers: {
+    item: process.env.CAREERS_SELECTOR_ITEM?.split(',') || [
+      '[data-job-card]',
+      '.job-card',
+      '.career-item',
+      'li.job'
+    ],
+    title: process.env.CAREERS_SELECTOR_TITLE?.split(',') || ['.job-title', 'h3', 'a'],
+    location: process.env.CAREERS_SELECTOR_LOCATION?.split(',') || ['.job-location', '.location', '[data-location]'],
+    type: process.env.CAREERS_SELECTOR_TYPE?.split(',') || ['.job-type', '.type'],
+    date: process.env.CAREERS_SELECTOR_DATE?.split(',') || ['time', '.date'],
+    link: process.env.CAREERS_SELECTOR_LINK?.split(',') || ['a']
+  },
+  loans: {
+    item: process.env.LOANS_SELECTOR_ITEM?.split(',') || [
+      '.loan-card',
+      '.product-card',
+      '.loan',
+      '.card'
+    ],
+    title: process.env.LOANS_SELECTOR_TITLE?.split(',') || ['.loan-title', 'h3', 'h2'],
+    rate: process.env.LOANS_SELECTOR_RATE?.split(',') || ['.apr', '.rate', '.markup'],
+    bullets: process.env.LOANS_SELECTOR_BULLETS?.split(',') || ['li'],
+    link: process.env.LOANS_SELECTOR_LINK?.split(',') || ['a']
+  }
+};

--- a/server/fetcher.js
+++ b/server/fetcher.js
@@ -1,0 +1,125 @@
+import LRUCache from 'lru-cache';
+import robotsParser from 'robots-parser';
+import { config } from './config.js';
+
+const pageCache = new LRUCache({ max: 200, ttl: config.cacheTtlMs });
+const robotsCache = new Map();
+
+export function isAllowedDomain(urlString) {
+  try {
+    const url = new URL(urlString);
+    return config.allowedDomains.includes(url.hostname);
+  } catch (error) {
+    return false;
+  }
+}
+
+async function fetchRobots(urlString) {
+  const url = new URL(urlString);
+  const origin = `${url.protocol}//${url.hostname}`;
+  if (robotsCache.has(origin)) return robotsCache.get(origin);
+
+  const robotsUrl = `${origin}/robots.txt`;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const res = await fetch(robotsUrl, {
+      headers: { 'User-Agent': 'NationalBankChatbot/1.0 (+public site use)' },
+      signal: controller.signal
+    });
+    clearTimeout(timeout);
+    if (!res.ok) {
+      const parser = robotsParser(robotsUrl, '');
+      robotsCache.set(origin, parser);
+      return parser;
+    }
+    const text = await res.text();
+    const parser = robotsParser(robotsUrl, text);
+    robotsCache.set(origin, parser);
+    return parser;
+  } catch (error) {
+    const parser = robotsParser(robotsUrl, '');
+    robotsCache.set(origin, parser);
+    return parser;
+  }
+}
+
+async function assertRobots(urlString) {
+  const parser = await fetchRobots(urlString);
+  const path = new URL(urlString).pathname;
+  const allowed = parser.isAllowed(path, 'NationalBankChatbot/1.0');
+  if (allowed === false) {
+    const err = new Error('Path disallowed by robots.txt');
+    err.code = 'ROBOTS_DISALLOWED';
+    throw err;
+  }
+}
+
+function exponentialDelay(attempt) {
+  return Math.min(1000, 200 * 2 ** attempt);
+}
+
+export async function safeFetch(urlString) {
+  if (!isAllowedDomain(urlString)) {
+    const err = new Error('Domain not allowlisted');
+    err.code = 'DOMAIN_NOT_ALLOWED';
+    throw err;
+  }
+
+  await assertRobots(urlString);
+
+  const cached = pageCache.get(urlString);
+  if (cached) {
+    return { text: cached, cached: true };
+  }
+
+  let attempt = 0;
+  let lastError;
+  while (attempt < 3) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 2000);
+      const response = await fetch(urlString, {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'NationalBankChatbot/1.0 (+public site use)'
+        }
+      });
+      clearTimeout(timeout);
+      if (!response.ok) {
+        throw new Error(`Fetch failed with status ${response.status}`);
+      }
+      const text = await response.text();
+      pageCache.set(urlString, text);
+      return { text, cached: false };
+    } catch (error) {
+      lastError = error;
+      const wait = exponentialDelay(attempt);
+      await new Promise((resolve) => setTimeout(resolve, wait));
+      attempt += 1;
+    }
+  }
+  throw lastError || new Error('Failed to fetch resource');
+}
+
+export function normalizeUrl(maybeUrl, base) {
+  try {
+    const url = new URL(maybeUrl, base);
+    if (!isAllowedDomain(url.href)) {
+      return null;
+    }
+    return url.href;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function getCacheStats() {
+  const stats = pageCache.stats || { hits: 0, misses: 0 }; // stats available in lru-cache v10+
+  return {
+    size: pageCache.size,
+    hits: stats.hits || 0,
+    misses: stats.misses || 0,
+    ttlMs: config.cacheTtlMs
+  };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,98 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import csrf from 'csurf';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+
+import { config } from './config.js';
+import { routeIntent } from './intents.js';
+import { recordMetric, snapshotMetrics } from './analytics.js';
+import { getCacheStats } from './fetcher.js';
+import { locales, resolveLocale } from './locale.js';
+
+const app = express();
+
+app.use(helmet({
+  contentSecurityPolicy: {
+    useDefaults: true,
+    directives: {
+      'script-src': ["'self'"],
+      'connect-src': ["'self'"],
+      'img-src': ["'self'", 'data:'],
+      'frame-ancestors': ["'self'"]
+    }
+  },
+  crossOriginEmbedderPolicy: false
+}));
+app.use(express.json({ limit: '1mb' }));
+app.use(cookieParser());
+app.use('/public', express.static('public', { immutable: true, maxAge: '7d' }));
+
+const limiter = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+app.use('/api/', limiter);
+
+const csrfProtection = csrf({
+  cookie: {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production'
+  }
+});
+
+app.get('/api/csrf', csrfProtection, (req, res) => {
+  res.json({ token: req.csrfToken() });
+});
+
+app.get('/api/health', (req, res) => {
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    metrics: snapshotMetrics(),
+    cache: getCacheStats()
+  });
+});
+
+app.post('/api/ask', csrfProtection, async (req, res) => {
+  const started = Date.now();
+  try {
+    const localeKey = resolveLocale(req.body?.locale || config.localeDefault);
+    const question = String(req.body?.q || '').slice(0, 500);
+    if (!question) {
+      return res.status(400).json({ error: 'Question is required.' });
+    }
+    const result = await routeIntent(question, localeKey);
+    const latency = Date.now() - started;
+    recordMetric({ intent: result.intent, success: true, latencyMs: latency });
+    res.json({ ...result, locale: localeKey });
+  } catch (error) {
+    const latency = Date.now() - started;
+    recordMetric({ intent: 'error', success: false, latencyMs: latency });
+    res.status(500).json({
+      intent: 'error',
+      as_of: new Date().toISOString(),
+      message: 'Unable to complete the request safely right now.',
+      disclaimer: locales[config.localeDefault].disclaimer
+    });
+  }
+});
+
+app.use((err, req, res, next) => {
+  if (err.code === 'EBADCSRFTOKEN') {
+    return res.status(403).json({ error: 'Invalid CSRF token.' });
+  }
+  if (err.code === 'PAYLOAD_TOO_LARGE') {
+    return res.status(413).json({ error: 'Payload too large.' });
+  }
+  return next(err);
+});
+
+app.listen(config.port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Chatbot server listening on port ${config.port}`);
+});

--- a/server/intents.js
+++ b/server/intents.js
@@ -1,0 +1,207 @@
+import { config } from './config.js';
+import { safeFetch } from './fetcher.js';
+import { parseCareers, parseLoans, extractTableRows, sanitizeCopy } from './scraping.js';
+import { locales, resolveLocale } from './locale.js';
+
+const HANDOFF_LINK = process.env.HANDOFF_URL || config.contactUrl;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function buildBase(intent, localeKey) {
+  const locale = locales[localeKey];
+  return {
+    intent,
+    as_of: nowIso(),
+    sources: [],
+    cards: [],
+    chips: locale.quickChips,
+    disclaimer: locale.disclaimer,
+    handoff: HANDOFF_LINK
+      ? { label: locale.handoffLabel, href: HANDOFF_LINK }
+      : null
+  };
+}
+
+function withSource(payload, sourceUrl) {
+  if (sourceUrl) {
+    payload.sources = Array.from(new Set([...(payload.sources || []), sourceUrl]));
+  }
+  return payload;
+}
+
+function sanitizeMessage(message) {
+  return sanitizeCopy(message);
+}
+
+function containsAccountLanguage(text) {
+  return /(account|statement|balance|card number|password|pin|otp|login|transfer)/i.test(text);
+}
+
+export async function routeIntent(question, localeKey = config.localeDefault) {
+  const locale = resolveLocale(localeKey);
+  const q = String(question || '').trim();
+  if (!q) {
+    const res = buildBase('general.faq', locale);
+    res.message = sanitizeMessage(locales[locale].faqPrompt);
+    return res;
+  }
+
+  if (containsAccountLanguage(q)) {
+    const res = buildBase('general.faq', locale);
+    res.message = sanitizeMessage(locales[locale].accountRedirect);
+    if (config.contactUrl) {
+      res.cards.push({
+        title: 'Secure Support Portal',
+        actions: [{ label: 'Sign in', href: config.contactUrl }]
+      });
+      res.sources.push(config.contactUrl);
+    }
+    return res;
+  }
+
+  const lower = q.toLowerCase();
+
+  if (/(job|career|opening|vacancy|position)/.test(lower)) {
+    const res = buildBase('jobs.openings', locale);
+    if (!config.careersUrl) {
+      res.message = sanitizeMessage('The careers page is not configured yet.');
+      return res;
+    }
+    try {
+      const { text } = await safeFetch(config.careersUrl);
+      const cards = parseCareers(text, config.careersUrl);
+      if (cards.length) {
+        res.cards = cards;
+        res.message = sanitizeMessage('Here are the latest openings from our Careers page.');
+      } else {
+        res.message = sanitizeMessage("I couldn't find current openings. Please check the Careers site.");
+      }
+      withSource(res, config.careersUrl);
+      return res;
+    } catch (error) {
+      res.message = sanitizeMessage("I couldn't reach the Careers page safely. Please visit the official site.");
+      withSource(res, config.careersUrl);
+      return res;
+    }
+  }
+
+  if (/(loan|finance|mortgage|auto|personal|home)/.test(lower)) {
+    const res = buildBase('loans.products', locale);
+    if (!config.loansUrl) {
+      res.message = sanitizeMessage('Our loans catalog is not configured yet.');
+      return res;
+    }
+    try {
+      const { text } = await safeFetch(config.loansUrl);
+      const cards = parseLoans(text, config.loansUrl);
+      if (cards.length) {
+        res.cards = cards;
+        res.message = sanitizeMessage('Here are loan products currently listed on our site.');
+      } else {
+        res.message = sanitizeMessage('I could not extract loan details. Please review the loans page directly.');
+      }
+      withSource(res, config.loansUrl);
+      return res;
+    } catch (error) {
+      res.message = sanitizeMessage('I could not reach the loans page. Please use the official site link.');
+      withSource(res, config.loansUrl);
+      return res;
+    }
+  }
+
+  if (/(branch|atm|location|nearby|visit)/.test(lower)) {
+    const res = buildBase('branches.lookup', locale);
+    const url = config.branchesUrl || config.contactUrl || config.faqUrl;
+    res.message = sanitizeMessage('Use our official Branch & ATM finder for the most accurate information.');
+    if (url) {
+      res.cards.push({
+        title: 'Branch & ATM Finder',
+        actions: [{ label: 'Open finder', href: url }]
+      });
+      withSource(res, url);
+    }
+    return res;
+  }
+
+  if (/(rate|markup|apr|interest|fee)/.test(lower)) {
+    const res = buildBase('rates.fees', locale);
+    const url = config.loansUrl || config.faqUrl || config.sitemapUrl;
+    if (url) {
+      try {
+        const { text } = await safeFetch(url);
+        const rows = extractTableRows(text);
+        if (rows.length) {
+          res.message = sanitizeMessage('Here are the current rates & fees published on our site.');
+          res.cards = rows.slice(0, 4).map((cells) => ({
+            title: cells[0],
+            subtitle: cells.slice(1).join(' • ')
+          }));
+        } else {
+          res.message = sanitizeMessage('I could not find a rates table. Please review the official page.');
+        }
+        withSource(res, url);
+      } catch (error) {
+        res.message = sanitizeMessage('I could not reach the rates page right now.');
+        withSource(res, url);
+      }
+    } else {
+      res.message = sanitizeMessage('A rates or fees page is not configured yet.');
+    }
+    return res;
+  }
+
+  if (/(contact|phone|email|support|helpdesk|customer service)/.test(lower)) {
+    const res = buildBase('contact.options', locale);
+    const url = config.contactUrl || config.faqUrl;
+    res.message = sanitizeMessage('Here are our official contact options.');
+    if (url) {
+      try {
+        const { text } = await safeFetch(url);
+        const contacts = [];
+        const phoneMatch = text.match(/\+?[0-9][0-9\s\-]{6,}/);
+        if (phoneMatch) {
+          contacts.push({ title: 'Phone', subtitle: phoneMatch[0] });
+        }
+        const emailMatch = text.match(/([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)/);
+        if (emailMatch) {
+          contacts.push({ title: 'Email', subtitle: emailMatch[0] });
+        }
+        if (!contacts.length) {
+          contacts.push({ title: 'Customer Care', subtitle: 'Visit our contact page for the latest details.' });
+        }
+        res.cards = contacts;
+        withSource(res, url);
+      } catch (error) {
+        res.cards.push({ title: 'Customer Care', actions: [{ label: 'Visit contact page', href: url }] });
+        withSource(res, url);
+      }
+    }
+    return res;
+  }
+
+  if (/(human|agent|representative|escalate|handoff)/.test(lower)) {
+    const res = buildBase('handoff', locale);
+    if (res.handoff) {
+      res.message = sanitizeMessage('You can reach a human representative using the link below.');
+      res.cards.push({ title: 'Human support', actions: [{ label: res.handoff.label, href: res.handoff.href }] });
+      withSource(res, res.handoff.href);
+    } else {
+      res.message = sanitizeMessage('A human support link is not configured yet.');
+    }
+    return res;
+  }
+
+  const res = buildBase('general.faq', locale);
+  res.message = sanitizeMessage(`${locales[locale].fallback} ${config.faqUrl ? '' : locales[locale].faqPrompt}`.trim());
+  if (config.faqUrl) {
+    res.cards.push({
+      title: 'FAQ Centre',
+      subtitle: sanitizeMessage(locales[locale].faqPrompt),
+      actions: [{ label: 'Open FAQ', href: config.faqUrl }]
+    });
+    withSource(res, config.faqUrl);
+  }
+  return res;
+}

--- a/server/locale.js
+++ b/server/locale.js
@@ -1,0 +1,37 @@
+export const locales = {
+  en: {
+    assistantName: 'National Bank Assistant',
+    disclaimer: 'For general information only. No account information is processed in this chat.',
+    fallback: "I couldn't find that right now. Here's where to check:",
+    accountRedirect: 'For account-specific help, please sign in or contact support.',
+    faqPrompt: 'You can ask about jobs, loans, branches, fees, or contact options.',
+    quickChips: [
+      { label: 'Current Jobs', value: 'Current job openings' },
+      { label: 'Personal Loans', value: 'Personal loan options' },
+      { label: 'Find Branch', value: 'Find a branch or ATM' },
+      { label: 'Fees & Rates', value: 'Show current rates' },
+      { label: 'Contact', value: 'Customer service contact' }
+    ],
+    handoffLabel: 'Chat with a human'
+  },
+  ur: {
+    assistantName: 'نیشنل بینک اسسٹنٹ',
+    disclaimer: 'یہ چیٹ صرف عمومی معلومات کے لیے ہے۔ اکاؤنٹ کی تفصیلات پراسیس نہیں کی جاتیں۔',
+    fallback: 'میں فی الحال یہ معلومات نہیں ڈھونڈ سکا۔ براہ کرم اس لنک کو دیکھیں:',
+    accountRedirect: 'اکاؤنٹ سے متعلق مدد کیلئے لاگ ان کریں یا سپورٹ سے رابطہ کریں۔',
+    faqPrompt: 'ملازمتیں، قرض، برانچز، فیس یا رابطہ کے بارے میں پوچھیں۔',
+    quickChips: [
+      { label: 'موجودہ نوکریاں', value: 'موجودہ ملازمتیں' },
+      { label: 'پرَسنل لون', value: 'ذاتی قرض کی تفصیل' },
+      { label: 'برانچ تلاش کریں', value: 'قریب ترین برانچ' },
+      { label: 'فیس اور شرح', value: 'موجودہ شرحیں' },
+      { label: 'رابطہ', value: 'کسٹمر سروس رابطہ' }
+    ],
+    handoffLabel: 'انسانی ایجنٹ سے بات کریں'
+  }
+};
+
+export function resolveLocale(localeKey) {
+  if (localeKey && locales[localeKey]) return localeKey;
+  return 'en';
+}

--- a/server/scraping.js
+++ b/server/scraping.js
@@ -1,0 +1,110 @@
+import { JSDOM } from 'jsdom';
+import { selectors } from './config.js';
+import { normalizeUrl } from './fetcher.js';
+
+function pickFirstText(element, selectorList) {
+  for (const selector of selectorList) {
+    const target = selector === ':self' ? element : element.querySelector(selector);
+    if (target && target.textContent?.trim()) {
+      return target.textContent.trim();
+    }
+  }
+  return '';
+}
+
+function pickFirstAttr(element, selectorList, attribute) {
+  for (const selector of selectorList) {
+    const target = selector === ':self' ? element : element.querySelector(selector);
+    if (target && target.getAttribute?.(attribute)) {
+      return target.getAttribute(attribute);
+    }
+  }
+  return '';
+}
+
+export function sanitizeCopy(input) {
+  return String(input || '')
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .trim();
+}
+
+export function parseCareers(html, baseUrl) {
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const uniqueNodes = new Set();
+  selectors.careers.item.forEach((selector) => {
+    doc.querySelectorAll(selector).forEach((node) => uniqueNodes.add(node));
+  });
+
+  const cards = [];
+  for (const node of uniqueNodes) {
+    const title = sanitizeCopy(pickFirstText(node, selectors.careers.title));
+    if (!title) continue;
+    const location = sanitizeCopy(pickFirstText(node, selectors.careers.location));
+    const type = sanitizeCopy(pickFirstText(node, selectors.careers.type));
+    const dateRaw = pickFirstAttr(node, selectors.careers.date, 'datetime') || pickFirstText(node, selectors.careers.date);
+    const date = sanitizeCopy(dateRaw);
+    const hrefRaw = pickFirstAttr(node, selectors.careers.link, 'href');
+    const href = normalizeUrl(hrefRaw, baseUrl);
+
+    const subtitleParts = [location, type].filter(Boolean);
+    cards.push({
+      title,
+      subtitle: subtitleParts.join(' — '),
+      badges: date ? [`Posted: ${date}`] : [],
+      actions: href ? [{ label: 'Apply', href }] : []
+    });
+    if (cards.length >= 20) break;
+  }
+  return cards;
+}
+
+export function parseLoans(html, baseUrl) {
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const uniqueNodes = new Set();
+  selectors.loans.item.forEach((selector) => {
+    doc.querySelectorAll(selector).forEach((node) => uniqueNodes.add(node));
+  });
+
+  const cards = [];
+  for (const node of uniqueNodes) {
+    const title = sanitizeCopy(pickFirstText(node, selectors.loans.title));
+    if (!title) continue;
+    const rate = sanitizeCopy(pickFirstText(node, selectors.loans.rate));
+    const bullets = [];
+    selectors.loans.bullets.forEach((selector) => {
+      node.querySelectorAll(selector).forEach((li) => {
+        const copy = sanitizeCopy(li.textContent);
+        if (copy) bullets.push(copy);
+      });
+    });
+    const hrefRaw = pickFirstAttr(node, selectors.loans.link, 'href');
+    const href = normalizeUrl(hrefRaw, baseUrl);
+    cards.push({
+      title,
+      subtitle: rate,
+      badges: bullets.slice(0, 3),
+      actions: href ? [{ label: 'View details', href }] : []
+    });
+    if (cards.length >= 12) break;
+  }
+  return cards;
+}
+
+export function extractTableRows(html, selector = 'table') {
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const table = doc.querySelector(selector);
+  if (!table) return [];
+  const rows = [];
+  table.querySelectorAll('tr').forEach((row) => {
+    const cells = [...row.querySelectorAll('th,td')]
+      .map((cell) => sanitizeCopy(cell.textContent))
+      .filter(Boolean);
+    if (cells.length) rows.push(cells);
+  });
+  return rows;
+}

--- a/tests/fetcher.test.js
+++ b/tests/fetcher.test.js
@@ -1,0 +1,12 @@
+import { beforeEach, expect, test } from '@jest/globals';
+
+beforeEach(() => {
+  process.env.ALLOWED_DOMAINS = 'bank.example.com,www.bank.example.com';
+});
+
+test('isAllowedDomain respects allowlist', async () => {
+  jest.resetModules();
+  const { isAllowedDomain } = await import('../server/fetcher.js');
+  expect(isAllowedDomain('https://bank.example.com/careers')).toBe(true);
+  expect(isAllowedDomain('https://evil.example.com/')).toBe(false);
+});

--- a/tests/intents.test.js
+++ b/tests/intents.test.js
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const sampleCareers = `
+  <article class="job-card">
+    <a class="job-title" href="/careers/ops">Operations Manager</a>
+    <div class="job-location">Karachi</div>
+    <div class="job-type">Full-time</div>
+    <time datetime="2025-09-20"></time>
+  </article>
+`;
+
+const sampleLoans = `
+  <div class="product-card">
+    <h3>Auto Loan</h3>
+    <div class="apr">Markup 10%</div>
+    <ul>
+      <li>Up to PKR 4M</li>
+      <li>Tenure 7 years</li>
+    </ul>
+    <a href="/loans/auto"></a>
+  </div>
+`;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env.ALLOWED_DOMAINS = 'bank.example.com';
+  process.env.CAREERS_URL = 'https://bank.example.com/careers';
+  process.env.LOANS_URL = 'https://bank.example.com/loans';
+  process.env.FAQ_URL = 'https://bank.example.com/faq';
+  process.env.CONTACT_URL = 'https://bank.example.com/contact';
+});
+
+describe('routeIntent', () => {
+  test('routes job queries to careers scraper', async () => {
+    const safeFetchMock = jest.fn(async (url) => {
+      if (url.includes('careers')) return { text: sampleCareers };
+      throw new Error('unexpected url');
+    });
+
+    jest.unstable_mockModule('../server/fetcher.js', () => ({
+      safeFetch: safeFetchMock,
+      normalizeUrl: (href, base) => new URL(href, base).href,
+      getCacheStats: () => ({}),
+      isAllowedDomain: () => true
+    }));
+
+    const { routeIntent } = await import('../server/intents.js');
+    const response = await routeIntent('What jobs are open in Karachi?', 'en');
+    expect(response.intent).toBe('jobs.openings');
+    expect(response.cards.length).toBeGreaterThan(0);
+    expect(safeFetchMock).toHaveBeenCalledWith('https://bank.example.com/careers');
+  });
+
+  test('returns fallback for unknown query', async () => {
+    const safeFetchMock = jest.fn(async () => ({ text: '' }));
+    jest.unstable_mockModule('../server/fetcher.js', () => ({
+      safeFetch: safeFetchMock,
+      normalizeUrl: (href, base) => new URL(href, base).href,
+      getCacheStats: () => ({}),
+      isAllowedDomain: () => true
+    }));
+
+    const { routeIntent } = await import('../server/intents.js');
+    const response = await routeIntent('hello there', 'en');
+    expect(response.intent).toBe('general.faq');
+    expect(response.cards.length).toBeGreaterThanOrEqual(0);
+  });
+
+  test('returns loan products when available', async () => {
+    const safeFetchMock = jest.fn(async (url) => {
+      if (url.includes('loans')) {
+        return { text: sampleLoans };
+      }
+      return { text: '' };
+    });
+    jest.unstable_mockModule('../server/fetcher.js', () => ({
+      safeFetch: safeFetchMock,
+      normalizeUrl: (href, base) => new URL(href, base).href,
+      getCacheStats: () => ({}),
+      isAllowedDomain: () => true
+    }));
+
+    const { routeIntent } = await import('../server/intents.js');
+    const response = await routeIntent('What loans do you offer?', 'en');
+    expect(response.intent).toBe('loans.products');
+    expect(response.cards[0].title).toContain('Auto Loan');
+  });
+
+  test('protects account-specific queries', async () => {
+    const safeFetchMock = jest.fn(async () => ({ text: '' }));
+    jest.unstable_mockModule('../server/fetcher.js', () => ({
+      safeFetch: safeFetchMock,
+      normalizeUrl: (href, base) => new URL(href, base).href,
+      getCacheStats: () => ({}),
+      isAllowedDomain: () => true
+    }));
+
+    const { routeIntent } = await import('../server/intents.js');
+    const response = await routeIntent('I forgot my account password', 'en');
+    expect(response.message).toMatch(/sign in/i);
+    expect(response.intent).toBe('general.faq');
+  });
+});

--- a/tests/scraping.test.js
+++ b/tests/scraping.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, test, beforeAll } from '@jest/globals';
+
+beforeAll(() => {
+  process.env.ALLOWED_DOMAINS = 'bank.example.com';
+});
+
+test('parseCareers extracts job cards', async () => {
+  jest.resetModules();
+  const { parseCareers } = await import('../server/scraping.js');
+  const html = `
+    <ul>
+      <li class="job-card">
+        <a href="/careers/123" class="job-title">Branch Operations Officer</a>
+        <span class="job-location">Karachi</span>
+        <span class="job-type">Full-time</span>
+        <time datetime="2025-09-28"></time>
+      </li>
+    </ul>
+  `;
+  const cards = parseCareers(html, 'https://bank.example.com/careers');
+  expect(cards).toHaveLength(1);
+  expect(cards[0].title).toContain('Branch Operations Officer');
+  expect(cards[0].actions[0].href).toBe('https://bank.example.com/careers/123');
+});
+
+test('parseLoans extracts loan cards with bullets', async () => {
+  jest.resetModules();
+  const { parseLoans } = await import('../server/scraping.js');
+  const html = `
+    <section class="product-card">
+      <h3>Personal Loan</h3>
+      <div class="apr">Markup 12%</div>
+      <ul>
+        <li>Up to PKR 2M</li>
+        <li>Tenure 5 years</li>
+      </ul>
+      <a href="/loans/personal"></a>
+    </section>
+  `;
+  const cards = parseLoans(html, 'https://bank.example.com/loans');
+  expect(cards).toHaveLength(1);
+  expect(cards[0].subtitle).toContain('12%');
+  expect(cards[0].badges.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add an Express backend with allowlisted scraping utilities, intent routing, CSRF protection, and lightweight analytics for the banking chatbot
- build an accessible green and white chat widget with quick replies, locale/theme toggles, and timestamped answers sourced from the backend
- document setup plus add scraping and intent unit tests along with a minimal technical spec in the README

## Testing
- npm install *(fails: 403 Forbidden fetching npm packages in the execution environment)*
- npm test *(fails: `jest` not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_68de0f6673d8832bbd6bd4acdbe6128b